### PR TITLE
Remove orphan "blocks"

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -21,8 +21,7 @@ also be written as:
     say
     "Hello"; say "World";
 
-X<blocks|control flow, blocks>
-=head1 Blocks
+=head1 X<blocks|control flow, blocks>
 
 Like many languages, Perl 6 uses C<blocks> enclosed by C<{> and C<}> to turn
 multiple statements into a single statement.  It is OK to skip the semicolon


### PR DESCRIPTION
## The problem

Typo in the "blocks " header means we have a line that just says "blocks" directly before the Blocks header.

> ![image](https://user-images.githubusercontent.com/2691108/55945444-b7a2af80-5c42-11e9-8de9-c6a5a68ffb11.png)

## Solution provided

fix the typo

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
